### PR TITLE
added proxy param to  RemoteConnection

### DIFF
--- a/qasm/dwave.py
+++ b/qasm/dwave.py
@@ -24,7 +24,8 @@ def connect_to_dwave():
     try:
         url = os.environ["DW_INTERNAL__HTTPLINK"]
         token = os.environ["DW_INTERNAL__TOKEN"]
-        conn = RemoteConnection(url, token)
+        proxy = os.environ["DW_INTERNAL__HTTPPROXY"]
+        conn = RemoteConnection(url, token, proxy)
     except KeyError:
         url = "<local>"
         token = "<N/A>"


### PR DESCRIPTION
Hi, I was not able to get a connection to dwave because of the missing proxy parameter. I just added that, it now works great.